### PR TITLE
Fix onPurchaseFailed callback call

### DIFF
--- a/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
+++ b/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
@@ -611,7 +611,7 @@ namespace Google.Play.Billing
 
                 // Copy _productInPurchaseFlow.id into the delegate as the delegate is called by the main thread and
                 // _productInPurchaseFlow will get cleaned up immediately in this thread.
-                var productId = _productInPurchaseFlow.id;
+                var productId = _productInPurchaseFlow.storeSpecificId;
                 _billingUtil.RunOnMainThread(() =>
                     _callback.OnPurchaseFailed(
                         new PurchaseFailureDescription(productId, purchaseFailureReason, debugMessage)));

--- a/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
+++ b/GooglePlayPlugins/com.google.play.billing/Runtime/Scripts/GooglePlayStoreImpl.cs
@@ -146,7 +146,7 @@ namespace Google.Play.Billing
             {
                 _billingUtil.RunOnMainThread(() =>
                     _callback.OnPurchaseFailed(
-                        new PurchaseFailureDescription(product.id, PurchaseFailureReason.ExistingPurchasePending,
+                        new PurchaseFailureDescription(product.storeSpecificId, PurchaseFailureReason.ExistingPurchasePending,
                             string.Format("A purchase for {0} is already in progress.",
                                 _productInPurchaseFlow.id))));
                 return;
@@ -169,7 +169,7 @@ namespace Google.Play.Billing
                     // A SKU that has ProductDefinition should appear in the inventory. If not, the issue could be
                     // transient so that it asks to try again later.
                     _callback.OnPurchaseFailed(
-                        new PurchaseFailureDescription(product.id, PurchaseFailureReason.ProductUnavailable,
+                        new PurchaseFailureDescription(product.storeSpecificId, PurchaseFailureReason.ProductUnavailable,
                             string.Format("Cannot purchase {0} now, please try again later.",
                                 _productInPurchaseFlow.id)));
                     return;
@@ -303,7 +303,7 @@ namespace Google.Play.Billing
             {
                 _billingUtil.RunOnMainThread(() =>
                     _callback.OnPurchaseFailed(
-                        new PurchaseFailureDescription(newProduct.definition.id,
+                        new PurchaseFailureDescription(newProduct.definition.storeSpecificId,
                             PurchaseFailureReason.ExistingPurchasePending,
                             string.Format("A purchase for {0} is already in progress.",
                                 _productInPurchaseFlow.id))));
@@ -319,7 +319,7 @@ namespace Google.Play.Billing
                     // A SKU that has ProductDefinition should appear in the inventory. If not, the issue could be
                     // transient so that it asks to try again later.
                     _callback.OnPurchaseFailed(
-                        new PurchaseFailureDescription(newProduct.definition.id,
+                        new PurchaseFailureDescription(newProduct.definition.storeSpecificId,
                             PurchaseFailureReason.ProductUnavailable,
                             string.Format("Cannot update subscription for {0} now, please try again later.",
                                 _productInPurchaseFlow.id)));
@@ -609,12 +609,12 @@ namespace Google.Play.Billing
                         break;
                 }
 
-                // Copy _productInPurchaseFlow.id into the delegate as the delegate is called by the main thread and
+                // Copy _productInPurchaseFlow.storeSpecificId into the delegate as the delegate is called by the main thread and
                 // _productInPurchaseFlow will get cleaned up immediately in this thread.
-                var productId = _productInPurchaseFlow.storeSpecificId;
+                var storeSpecificId = _productInPurchaseFlow.storeSpecificId;
                 _billingUtil.RunOnMainThread(() =>
                     _callback.OnPurchaseFailed(
-                        new PurchaseFailureDescription(productId, purchaseFailureReason, debugMessage)));
+                        new PurchaseFailureDescription(storeSpecificId, purchaseFailureReason, debugMessage)));
             }
 
             _productInPurchaseFlow = null;


### PR DESCRIPTION
Use storeSpecificId instead of internal unity productId during call OnPurchaseFailed